### PR TITLE
migrate to os2

### DIFF
--- a/extentions/common.odin
+++ b/extentions/common.odin
@@ -17,14 +17,13 @@ read_file :: proc(path: string, ext: ext_type) {
     
     dir := fmt.aprintf("./temp_%v", reflect.enum_name_from_value(ext))
     err := os.make_directory(dir)
-    if err != 0 {
+    if err != nil {
         fmt.println(err)
         return
     }
 
-    cur_dir := os.get_current_directory()
     err = os.set_current_directory(dir)
-    if err != 0 {
+    if err != nil {
         fmt.println(err)
         return
     }

--- a/marshal.odin
+++ b/marshal.odin
@@ -16,8 +16,8 @@ marshal_to_bytes_buff :: proc(doc: ^Document, b: ^bytes.Buffer, allocator := con
     return marshal(doc, w, allocator)
 }
 
-marshal_to_handle :: proc(doc: ^Document, h: os.Handle, allocator := context.allocator)-> (file_size: int, err: Marshal_Error) {
-    w, ok := io.to_writer(os.stream_from_handle(h))
+marshal_to_handle :: proc(doc: ^Document, fd: ^os.File, allocator := context.allocator)-> (file_size: int, err: Marshal_Error) {
+    w, ok := io.to_writer(os.to_stream(fd))
     if !ok {
         return file_size, .Unable_Make_Writer
     }

--- a/tests/ase_test.odin
+++ b/tests/ase_test.odin
@@ -56,8 +56,8 @@ ase_marshal :: proc(t: ^testing.T) {
 
 @(test)
 ase_full_test :: proc(t: ^testing.T) {
-    fd, f_err := os.open(".", os.O_RDONLY, 0)
-    base_f, FF_err := os.read_dir(fd, 0)
+    fd, f_err := os.open(".", os.O_RDONLY)
+    base_f, FF_err := os.read_dir(fd, 0, context.allocator)
     defer {
         for b in base_f {
             delete(b.fullpath)
@@ -68,10 +68,10 @@ ase_full_test :: proc(t: ^testing.T) {
     fmt.println(" ")
 
     for f in base_f {
-        if f.is_dir {
-            folder_h, f_err := os.open(f.fullpath, os.O_RDONLY, 0)
+        if f.type == .Directory {
+            folder_h, f_err := os.open(f.fullpath, os.O_RDONLY)
             defer os.close(folder_h)
-            sprites, ff_err := os.read_dir(folder_h, 0)
+            sprites, ff_err := os.read_dir(folder_h, 0, context.allocator)
             defer { 
                 for s in sprites {
                     delete(s.fullpath)
@@ -82,13 +82,13 @@ ase_full_test :: proc(t: ^testing.T) {
 
             for s in sprites {
                 if strings.has_suffix(s.name, ".aseprite") || strings.has_suffix(s.name, ".ase") {
-                    file_h, f_err := os.open(s.fullpath, os.O_RDONLY, 0)
+                    file_h, f_err := os.open(s.fullpath, os.O_RDONLY)
                     defer os.close(file_h)
-                    data, ok := os.read_entire_file(file_h)
+                    data, err := os.read_entire_file(file_h, context.allocator)
                     defer delete(data)
 
-                    if !ok {
-                        testing.fail_now(t, fmt.tprintf("%s: Failed to load file %v", #procedure, s.name))
+                    if err != nil {
+                        testing.fail_now(t, fmt.tprintf("%s: Failed to load file %v. OS err: %v", #procedure, s.name, err))
                     }
                     fmt.println("   Testing:", s.name)
 

--- a/tests/chunk_equal.odin
+++ b/tests/chunk_equal.odin
@@ -1,3 +1,4 @@
+#+feature using-stmt
 package ase_tests
 
 import "core:slice"

--- a/tests/common.odin
+++ b/tests/common.odin
@@ -1,3 +1,4 @@
+#+feature using-stmt
 package ase_tests
 
 import "core:os"
@@ -43,8 +44,8 @@ report :: proc(t: ^testing.T) {
 // e.g. get_data_path("assets/blah") will return "/Odin_root/tests/assets/blah" if run within "/Odin_root",
 // "/Odin_root/tests" or "/Odin_root/tests/subdir" etc
 get_data_path :: proc(t: ^testing.T, sub_path: string) -> (data_path: string) {
-
-	cwd := os.get_current_directory()
+	cwd, err := os.get_working_directory(context.allocator)
+    assert(err != nil)
 	defer delete(cwd)
 
 	when ODIN_OS == .Windows {

--- a/tests/raw_test.odin
+++ b/tests/raw_test.odin
@@ -98,34 +98,35 @@ raw_full_test :: proc(t: ^testing.T) {
 		}
 	}
     
-    fd, f_err := os.open("./tests", os.O_RDONLY, 0)
-    base_f, FF_err := os.read_dir(fd, 0)
+    fd, f_err := os.open("./tests", os.O_RDONLY)
+    base_f, FF_err := os.read_dir(fd, 0, context.allocator)
     defer delete(base_f)
     os.close(fd)
 
     for f in base_f {
-        if f.is_dir {
-            folder_h, f_err := os.open(f.fullpath, os.O_RDONLY, 0)
+        if f.type == .Directory {
+            folder_h, f_err := os.open(f.fullpath, os.O_RDONLY)
             defer os.close(folder_h)
-            sprites, ff_err := os.read_dir(folder_h, 0)
+            sprites, ff_err := os.read_dir(folder_h, 0, context.allocator)
             defer delete(sprites)
 
             for s in sprites {
                 if strings.has_suffix(s.name, ".aseprite") || strings.has_suffix(s.name, ".ase") {
-                    file_h, f_err := os.open(s.fullpath, os.O_RDONLY, 0)
+                    file_h, f_err := os.open(s.fullpath, os.O_RDONLY)
+                    if f_err != nil do testing.fail_now(t, fmt.tprintf("Failed to open file. %v", f_err))
                     defer os.close(file_h)
-                    data, ok := os.read_entire_file(file_h)
+                    data, err := os.read_entire_file(file_h, context.allocator)
                     defer delete(data)
 
-                    if !ok {
-                        testing.fail_now(t, "Failed to load file")
+                    if err != nil {
+                        testing.fail_now(t, fmt.tprintf("Failed to load file. OS error: %v", err))
                     }
                     doc: raw.ASE_Document
                     defer raw.destroy_doc(&doc)
 
-                    err := raw.unmarshal(data[:], &doc)
+                    unmarshal_err := raw.unmarshal(data[:], &doc)
 
-                    expect(t, err == nil, fmt.tprintf("%s Error: %v, File: %v", #procedure, err, s.fullpath))
+                    expect(t, err == nil, fmt.tprintf("%s Error: %v, File: %v", #procedure, unmarshal_err, s.fullpath))
 
                 }
             }

--- a/unmarshal.odin
+++ b/unmarshal.odin
@@ -27,7 +27,7 @@ unmarshal_from_bufio :: proc(doc: ^Document, r: ^bufio.Reader, alloc: runtime.Al
 }
 
 unmarshal_from_filename :: proc(doc: ^Document, name: string, alloc: runtime.Allocator = {}) -> (err: Unmarshal_Error) {
-    fd, fd_err := os.open(name, os.O_RDONLY, 0)
+    fd, fd_err := os.open(name, os.O_RDONLY)
     if fd_err != nil {
         log.error("Unable to read because of:", fd_err)
         return fd_err
@@ -36,8 +36,8 @@ unmarshal_from_filename :: proc(doc: ^Document, name: string, alloc: runtime.All
     return unmarshal(doc, fd, alloc)
 }
 
-unmarshal_from_handle :: proc(doc: ^Document, h: os.Handle, alloc: runtime.Allocator = {}) -> (err: Unmarshal_Error) {
-    rr, ok := io.to_reader(os.stream_from_handle(h))
+unmarshal_from_handle :: proc(doc: ^Document, fd: ^os.File, alloc: runtime.Allocator = {}) -> (err: Unmarshal_Error) {
+    rr, ok := io.to_reader(os.to_stream(fd))
     if !ok {
         return .Unable_Make_Reader
     }


### PR DESCRIPTION
On master I get this:
```
[ERROR] --- [2026-02-12 18:51:32] [ase_test.odin:49:ase_marshal()] ase_marshal File: /asefile/basic-16x16.aseprite
[ERROR] --- [2026-02-12 18:51:32] [ase_test.odin:51:ase_marshal()] FAIL: Marshaled doesn't match input
```
Which is the same test failure on this branch.

I opted to use the `#+feature using-stmt` for the tests, and to default file permissions from the explicit zero which was present before. Everything else is just wiring up errors and allocators. I've verified that the changes work with my asset bundler which uses this package.

Tested against odin commit: 22a5792888ce37414e97877b0fa3210deec902f0